### PR TITLE
Don't allow the lab manager to accidentally change or delete a chatbot conversation

### DIFF
--- a/app/views/chatbots/edit.html.erb
+++ b/app/views/chatbots/edit.html.erb
@@ -19,34 +19,40 @@
   </div>
   <hr/>
   <div class="is-flex flex-direction-row is-justify-content-space-between">
-    <%= button_to "Finish Test",
-    finish_chatbot_path(@chatbot),
-    method: :patch,
-    class: "button is-link",
-    form: {
-      data: {
-        turbo_confirm: "Are you sure you want to finish your test?",
-      },
-    } %>
-    <div class="is-flex flex-direction-row">
-      <% if @chatbot.out_of_responses? %>
-        <!-- Don't show anything -->
-        <div/>
-      <% elsif @chatbot.waiting? %>
-        <%= button_to Chatbot::USER_HEAR_MORE,
-        send_hear_more_path(@chatbot),
-        method: :patch,
-        class: "button is-primary" %>
-      <% else %>
-        <%= button_to "Yes",
-        send_yes_path(@chatbot),
-        method: :patch,
-        class: "button is-primary mr-3" %>
-        <%= button_to "No",
-        send_no_path(@chatbot),
-        method: :patch,
-        class: "button is-primary" %>
-      <% end %>
+    <% if @chatbot.conversation_finished_at.present? %>
+      <!-- After the test is finished, we don't want to allow the user to modify the conversation -->
+      <!-- So only give them a "Back" button -->
+      <%= link_to "Back", chatbots_path, class: "button is-link" %>
+    <% else %>
+      <%= button_to "Finish Test",
+      finish_chatbot_path(@chatbot),
+      method: :patch,
+      class: "button is-link",
+      form: {
+        data: {
+          turbo_confirm: "Are you sure you want to finish your test?",
+        },
+      } %>
+      <div class="is-flex flex-direction-row">
+        <% if @chatbot.out_of_responses? %>
+          <!-- Don't show anything -->
+          <div/>
+        <% elsif @chatbot.waiting? %>
+          <%= button_to Chatbot::USER_HEAR_MORE,
+          send_hear_more_path(@chatbot),
+          method: :patch,
+          class: "button is-primary" %>
+        <% else %>
+          <%= button_to "Yes",
+          send_yes_path(@chatbot),
+          method: :patch,
+          class: "button is-primary mr-3" %>
+          <%= button_to "No",
+          send_no_path(@chatbot),
+          method: :patch,
+          class: "button is-primary" %>
+        <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/chatbots/index.html.erb
+++ b/app/views/chatbots/index.html.erb
@@ -27,11 +27,14 @@
               <td><%= local_time(c.conversation_finished_at) unless c.conversation_finished_at.blank? %></td>
               <td>
                 <div class="is-flex flex-direction-row">
-                  <%= link_to "Chat", edit_chatbot_path(c), class: "button is-small is-light mr-3" %>
+                  <%= link_to "View", edit_chatbot_path(c), class: "button is-small is-light mr-3" %>
                   <%= button_to "Delete",
                   chatbot_path(c),
                   method: :delete,
-                  class: "button is-small is-danger is-light" %>
+                  class: "button is-small is-danger is-light",
+                  data: {
+                    turbo_confirm: "Are you sure you want to delete this conversation?",
+                  } %>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
- Change the "Chat" button on the main page to say "View" instead.
- Add a confirmation popup when the user clicks "Delete" to make sure they don't accidentally delete it.
- Don't allow the user to ask for more strategies / re-finish the test if the conversation has already been completed.

Check these all work on the UAT site: https://chatty-uat.c3l.ai/